### PR TITLE
bug fixed

### DIFF
--- a/torchocr/datasets/RecDataSet.py
+++ b/torchocr/datasets/RecDataSet.py
@@ -213,6 +213,8 @@ class RecDataLoader:
                     return self.pack(batch_data)
         # deal with last batch
         except StopIteration:
+            if self.queue_1 == []:
+                raise StopIteration
             batch_data = self.queue_1
             self.queue_1 = list()
             return self.pack(batch_data)


### PR DESCRIPTION
修复：数据集长度都一致时调用RecDataLoader，将会导致其中一个队列为空，出现异常退出