### PR TITLE
Fix bug where opt command line parameters cannot be set properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist/
 ppocr/
 .idea/
 pretrain_models
+*.pt[h]

--- a/tools/utility.py
+++ b/tools/utility.py
@@ -39,7 +39,8 @@ class ArgsParser(ArgumentParser):
                     if idx == len(keys) - 2:
                         cur[key] = yaml.load(v, Loader=yaml.Loader)
                     else:
-                        cur[key] = {}
+                        if key not in cur:
+                            cur[key] = {}
                         cur = cur[key]
         return config
 

--- a/torchocr/utils/ckpt.py
+++ b/torchocr/utils/ckpt.py
@@ -61,7 +61,7 @@ def load_ckpt(model, cfg, optimizer=None, lr_scheduler=None, logger=None):
         # status['global_step'] = checkpoint['global_step']
         # status['epoch'] = checkpoint['epoch'] + 1
         # status['metrics'] = checkpoint['metrics']
-        status['epoch'] = checkpoint.get('epoch', 0)
+        status['epoch'] = checkpoint.get('epoch', 0) + 1
         status['global_step'] = checkpoint.get('global_step', 0)
         status['metrics'] = checkpoint.get('metrics', {})
     elif pretrained_model and os.path.exists(pretrained_model):

--- a/torchocr/utils/ckpt.py
+++ b/torchocr/utils/ckpt.py
@@ -54,11 +54,16 @@ def load_ckpt(model, cfg, optimizer=None, lr_scheduler=None, logger=None):
             optimizer.load_state_dict(checkpoint['optimizer'])
         if lr_scheduler is not None:
             lr_scheduler.load_state_dict(checkpoint['scheduler'])
-        logger.info(f"resume from checkpoint: {checkpoints} (epoch {checkpoint['epoch']})")
+        epoch = checkpoint.get('epoch', 'N/A')
+        logger.info(f"resume from checkpoint: {checkpoints} (epoch {epoch})")
+        # logger.info(f"resume from checkpoint: {checkpoints} (epoch {checkpoint['epoch']})")
 
-        status['global_step'] = checkpoint['global_step']
-        status['epoch'] = checkpoint['epoch'] + 1
-        status['metrics'] = checkpoint['metrics']
+        # status['global_step'] = checkpoint['global_step']
+        # status['epoch'] = checkpoint['epoch'] + 1
+        # status['metrics'] = checkpoint['metrics']
+        status['epoch'] = checkpoint.get('epoch', 0)
+        status['global_step'] = checkpoint.get('global_step', 0)
+        status['metrics'] = checkpoint.get('metrics', {})
     elif pretrained_model and os.path.exists(pretrained_model):
         load_pretrained_params(model, pretrained_model)
         logger.info(f"finetune from checkpoint: {pretrained_model}")


### PR DESCRIPTION
python tools/eval.py -c configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_student.yml \
    -o Global.pretrained_model=weights/ch_PP-OCRv3_det_distill/student.pth \
    Global.use_gpu=True \
    Eval.dataset.data_dir="/home/zhangxin/data_public/OCR/1_ICDAR2019-LSVT" \
    Eval.dataset.label_file_list="['/home/zhangxin/data_public/OCR/1_ICDAR2019-LSVT/train_1000.txt']"
当我在命令行指定参数时，发现data_dir设置不上，读代码发现了这个问题。
