### PR TITLE
将pytorch模型转为onnx，将来文本框分类、检测、识别

### DIFF
--- a/configs/det/PP-OCRv5/PP-OCRv5_mobile_det.yml
+++ b/configs/det/PP-OCRv5/PP-OCRv5_mobile_det.yml
@@ -7,7 +7,7 @@ Global:
   epoch_num: &epoch_num 100
   log_smooth_window: 20
   print_batch_step: 100
-  save_model_dir: ./output/PP-OCRv5_mobile_det
+  save_model_dir: ./output/det/PP-OCRv5_mobile_det
   output_dir: ./output/PP-OCRv5_mobile_det
   save_epoch_step: 10
   eval_batch_step:

--- a/configs/det/PP-OCRv5/PP-OCRv5_mobile_det.yml
+++ b/configs/det/PP-OCRv5/PP-OCRv5_mobile_det.yml
@@ -8,7 +8,7 @@ Global:
   log_smooth_window: 20
   print_batch_step: 100
   save_model_dir: ./output/det/PP-OCRv5_mobile_det
-  output_dir: ./output/PP-OCRv5_mobile_det
+  output_dir: ./output/det/PP-OCRv5_mobile_det
   save_epoch_step: 10
   eval_batch_step:
   - 0

--- a/configs/det/PP-OCRv5/PP-OCRv5_server_det.yml
+++ b/configs/det/PP-OCRv5/PP-OCRv5_server_det.yml
@@ -7,7 +7,7 @@ Global:
   epoch_num: &epoch_num 100
   log_smooth_window: 20
   print_batch_step: 100
-  save_model_dir: ./output/PP-OCRv5_server_det
+  save_model_dir: ./output/det/PP-OCRv5_server_det
   output_dir: ./output/PP-OCRv5_server_det
   save_epoch_step: 10
   eval_batch_step:

--- a/configs/det/PP-OCRv5/PP-OCRv5_server_det.yml
+++ b/configs/det/PP-OCRv5/PP-OCRv5_server_det.yml
@@ -8,7 +8,7 @@ Global:
   log_smooth_window: 20
   print_batch_step: 100
   save_model_dir: ./output/det/PP-OCRv5_server_det
-  output_dir: ./output/PP-OCRv5_server_det
+  output_dir: ./output/det/PP-OCRv5_server_det
   save_epoch_step: 10
   eval_batch_step:
   - 0

--- a/configs/rec/PP-OCRv5/PP-OCRv5_mobile_rec.yml
+++ b/configs/rec/PP-OCRv5/PP-OCRv5_mobile_rec.yml
@@ -5,7 +5,8 @@ Global:
   epoch_num: 100
   log_smooth_window: 20
   print_batch_step: 100
-  save_model_dir: ./output/PP-OCRv5_mobile_rec
+  save_model_dir: ./output/rec/PP-OCRv5_mobile_rec
+  output_dir: ./output/rec/PP-OCRv5_mobile_rec
   save_epoch_step: 10
   eval_batch_step: [0, 2000]
   cal_metric_during_train: true

--- a/configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml
+++ b/configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml
@@ -6,6 +6,7 @@ Global:
   log_smooth_window: 20
   print_batch_step: 100
   save_model_dir: ./output/PP-OCRv5_server_rec
+  output_dir: ./output/PP-OCRv5_server_rec
   save_epoch_step: 10
   eval_batch_step: [0, 2000]
   cal_metric_during_train: true

--- a/configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml
+++ b/configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml
@@ -5,8 +5,8 @@ Global:
   epoch_num: 100
   log_smooth_window: 20
   print_batch_step: 100
-  save_model_dir: ./output/PP-OCRv5_server_rec
-  output_dir: ./output/PP-OCRv5_server_rec
+  save_model_dir: ./output/rec/PP-OCRv5_server_rec
+  output_dir: ./output/rec/PP-OCRv5_server_rec
   save_epoch_step: 10
   eval_batch_step: [0, 2000]
   cal_metric_during_train: true

--- a/torchocr/modeling/necks/rnn.py
+++ b/torchocr/modeling/necks/rnn.py
@@ -9,21 +9,10 @@ class Im2Seq(nn.Module):
         self.out_channels = in_channels
 
     def forward(self, x):
-        # B, C, H, W = x.shape
-        # assert H == 1
-        # x = x.squeeze(dim=2)
-        if len(x.shape) == 4:
-            # 如果是 [N, C, H, W]，通常需要先压平 H 维（如果是识别任务，H 通常为 1）
-            # 或者直接根据逻辑处理
-            # N, C, H, W = x.shape
-            # if H != 1:
-            #     # 如果 H 不为 1，可能需要 pool 或者 view
-            #     x = x.reshape(N, C, H * W)
-            # else:
-            #     x = x.squeeze(2)  # 变成 [N, C, W]
-            # B, C, H, W -> B, C, (H*W)
-            # 对于 OCR 识别，H 通常会被压缩为 1，所以 flatten(2) 等价于 squeeze(2)
-            x = x.flatten(2)
+        if x.dim() == 4:
+            B, C, H, W = x.shape
+            assert H == 1, f"Expected H=1, got H={H}"
+            x = x.squeeze(2)  # (B, C, W)
         x = x.permute(0, 2, 1)
         return x
 

--- a/torchocr/modeling/necks/rnn.py
+++ b/torchocr/modeling/necks/rnn.py
@@ -17,6 +17,7 @@ class Im2Seq(nn.Module):
         '''
         if len(x.shape) == 4:
             n, c, h, w = x.shape
+            assert h == 1, f"SVTR output H must be 1, got {h}"
             x = x.reshape(n, c * h, w)
         x = x.permute(0, 2, 1)
         return x
@@ -146,7 +147,8 @@ class EncoderWithSVTR(nn.Module):
             z = blk(z)
         z = self.norm(z)
         # last stage
-        z = z.reshape([-1, H, W, C]).permute([0, 3, 1, 2])
+        B = z.shape[0]
+        z = z.reshape(B, H, W, C).permute(0, 3, 1, 2)
         z = self.conv3(z)
         z = torch.cat((h, z), dim=1)
         z = self.conv1x1(self.conv4(z))

--- a/torchocr/modeling/necks/rnn.py
+++ b/torchocr/modeling/necks/rnn.py
@@ -9,10 +9,15 @@ class Im2Seq(nn.Module):
         self.out_channels = in_channels
 
     def forward(self, x):
+        '''
         if x.dim() == 4:
             B, C, H, W = x.shape
             assert H == 1, f"Expected H=1, got H={H}"
             x = x.squeeze(2)  # (B, C, W)
+        '''
+        if len(x.shape) == 4:
+            n, c, h, w = x.shape
+            x = x.reshape(n, c * h, w)
         x = x.permute(0, 2, 1)
         return x
 


### PR DESCRIPTION
模型转换
```bash
# cls
python tools/export.py -c configs/cls/cls_mv3.yml -o Global.pretrained_model=weights/ch_ppocr_mobile_v2.0_cls_train/best_accuracy.pth
# ./output/cls/mv3/export/model.onnx

# det
python tools/export.py -c configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_student.yml -o Global.pretrained_model=weights/ch_PP-OCRv3_det_distill/student.pth
# ./output/det/ch_PP-OCR_V3_det/export/model.onnx

python tools/export.py -c configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_student.yml -o Global.pretrained_model=weights/ch_PP-OCRv4_det_train/best_accuracy.pth
# ./output/det/ch_PP-OCRv4/export/model.onnx

python tools/export.py -c configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_teacher.yml -o Global.pretrained_model=weights/ch_PP-OCRv4_det_server_train/best_accuracy.pth
# ./output/det/h_PP-OCRv4_hgnet/export/model.onnx

python tools/export.py -c configs/det/PP-OCRv5/PP-OCRv5_mobile_det.yml -o Global.pretrained_model=/Users/zhangxin/github/PaddleOCR2Pytorch/models/ptocrv5/ptocr_v5_mobile_det.pth  Global.output_dir=./output/det/PP-OCRv5_mobile_det
# ./output/det/PP-OCRv5_mobile_det/export/model.onnx

python tools/export.py -c configs/det/PP-OCRv5/PP-OCRv5_server_det.yml -o Global.pretrained_model=/Users/zhangxin/github/PaddleOCR2Pytorch/models/ptocrv5/ptocr_v5_server_det.pth Global.output_dir=./output/det/PP-OCRv5_server_det
# ./output/det/PP-OCRv5_server_det/export/model.onnx


# rec
python tools/export.py -c configs/rec/PP-OCRv3/ch_PP-OCRv3_rec.yml -o Global.pretrained_model=weights/ch_PP-OCRv3_rec/student.pth
# ./output/rec/rec_ppocr_v3/export/model.onnx

python tools/export.py -c configs/rec/PP-OCRv4/ch_PP-OCRv4_rec.yml -o Global.pretrained_model=weights/ch_PP-OCRv4_rec_train/student.pth
# ./output/rec/rec_ppocr_v4/export/model.onnx

python tools/export.py -c configs/rec/PP-OCRv4/ch_PP-OCRv4_rec_hgnet.yml -o Global.pretrained_model=weights/ch_PP-OCRv4_rec_server_train/best_accuracy.pth
# ./output/rec/rec_ppocr_v4_hgnet/export/model.onnx

python tools/export.py -c configs/rec/PP-OCRv5/PP-OCRv5_mobile_rec.yml -o Global.pretrained_model=/Users/zhangxin/github/PaddleOCR2Pytorch/models/ptocrv5/ptocr_v5_mobile_rec.pth Global.output_dir=./output/rec/PP-OCRv5_mobile_rec
# ./output/rec/PP-OCRv5_mobile_rec/export/model.onnx

python tools/export.py -c configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml -o Global.pretrained_model=/Users/zhangxin/github/PaddleOCR2Pytorch/models/ptocrv5/ptocr_v5_server_rec.pth Global.output_dir=./output/rec/PP-OCRv5_server_rec
# ./output/rec/PP-OCRv5_server_rec/export/model.onnx
```